### PR TITLE
Update prepack to escape string when accessing jlink to build rt

### DIFF
--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -60,7 +60,7 @@ fi
 if [ ! -d "${JDK_RT}" ]; then
   mkdir ${JDK_RT}
   OUTPUT=${JDK_RT}/java
-  ${JAVA_HOME}/bin/jlink --add-modules java.base,java.xml,java.logging,java.management,jdk.unsupported,java.desktop,java.naming,java.sql,jdk.sctp,java.scripting \
+  "${JAVA_HOME}/bin/jlink" --add-modules java.base,java.xml,java.logging,java.management,jdk.unsupported,java.desktop,java.naming,java.sql,jdk.sctp,java.scripting \
   --output ${OUTPUT} --compress 2 --strip-debug
-  cp ${JAVA_HOME}/bin/jstack ${OUTPUT}/bin
+  cp "${JAVA_HOME}/bin/jstack" ${OUTPUT}/bin
 fi


### PR DESCRIPTION
This is required to build the slimmed down version of Java we use as part of AionWallet (usually this is found in the rt folder). The behavior of the wallet not launching is due to:

* The RT folder not being built because bash does not escape the jlink path link (which contains spaces).
* Subsequently, the removal (?) of rt from the packaging, but the rt folder is a mandatory part of the build.

This leads to AionWallet.exe (whose binary is based on a batch file) failing to launch due to not finding the java rt. You can find what the executable does here for next time:
https://github.com/aionnetwork/Desktop-Wallet/blob/master/scripts/aion_ui.bat